### PR TITLE
[Data Team] 实现笔记整理工具

### DIFF
--- a/scripts/tools/__init__.py
+++ b/scripts/tools/__init__.py
@@ -6,5 +6,14 @@ This package contains utility tools for the Knowledge Assistant system.
 """
 
 from scripts.tools.generate_index import generate_index, scan_directory
+from scripts.tools.organize_notes import (
+    organize_notes,
+    list_organization_plan,
+)
 
-__all__ = ["generate_index", "scan_directory"]
+__all__ = [
+    "generate_index",
+    "scan_directory",
+    "organize_notes",
+    "list_organization_plan",
+]

--- a/scripts/tools/organize_notes.py
+++ b/scripts/tools/organize_notes.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""
+Note Organization Tool.
+
+This module provides functionality to organize notes by date, tags,
+or other criteria, moving or copying them to target directories.
+
+Example:
+    >>> from scripts.tools.organize_notes import organize_notes
+    >>>
+    >>> # Organize notes by date
+    >>> result = organize_notes("notes/", "organized/", by="date")
+    >>> print(f"Organized {result.moved} notes")
+"""
+
+import shutil
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+from scripts.metadata_parser import MetadataParser
+from scripts.utils import ensure_directory, get_project_root
+
+
+@dataclass
+class DocumentInfo:
+    """
+    Information about a scanned document.
+
+    Attributes:
+        path (Path): The path to the document file.
+        title (str): The document title from metadata.
+        date (Optional[date]): The document date from metadata.
+        tags (List[str]): List of tags from metadata.
+        type (Optional[str]): The document type from metadata.
+        author (Optional[str]): The document author from metadata.
+    """
+
+    path: Path
+    title: str
+    date: Optional[date] = None
+    tags: List[str] = field(default_factory=list)
+    type: Optional[str] = None
+    author: Optional[str] = None
+
+
+@dataclass
+class OrganizationResult:
+    """
+    Result of note organization operation.
+
+    Attributes:
+        moved (int): Number of notes moved.
+        copied (int): Number of notes copied.
+        skipped (int): Number of notes skipped.
+        errors (List[str]): List of error messages.
+        details (Dict[str, str]): Mapping of source to destination paths.
+    """
+
+    moved: int = 0
+    copied: int = 0
+    skipped: int = 0
+    errors: List[str] = field(default_factory=list)
+    details: Dict[str, str] = field(default_factory=dict)
+
+
+def scan_directory(
+    directory: Union[str, Path],
+    recursive: bool = True,
+    extensions: Optional[List[str]] = None,
+) -> List[DocumentInfo]:
+    """
+    Scan a directory for markdown documents.
+
+    Args:
+        directory (Union[str, Path]): The directory to scan.
+        recursive (bool): Whether to scan subdirectories. Defaults to True.
+        extensions (Optional[List[str]]): File extensions to include.
+            Defaults to [".md", ".markdown"].
+
+    Returns:
+        List[DocumentInfo]: List of document information objects.
+    """
+    if extensions is None:
+        extensions = [".md", ".markdown"]
+
+    dir_path = Path(directory)
+    if not dir_path.is_absolute():
+        dir_path = get_project_root() / dir_path
+
+    if not dir_path.exists():
+        return []
+
+    documents: List[DocumentInfo] = []
+    parser = MetadataParser()
+
+    # Collect files
+    files: List[Path] = []
+    if recursive:
+        for ext in extensions:
+            files.extend(dir_path.rglob(f"*{ext}"))
+    else:
+        for ext in extensions:
+            files.extend(dir_path.glob(f"*{ext}"))
+
+    for file_path in files:
+        if not file_path.is_file():
+            continue
+
+        try:
+            content = file_path.read_text(encoding="utf-8")
+            metadata, _ = parser.parse(content)
+
+            # Extract title - use metadata or filename
+            title = metadata.get("title", file_path.stem)
+
+            # Extract date
+            doc_date = None
+            if "date" in metadata:
+                date_value = metadata["date"]
+                if isinstance(date_value, date):
+                    doc_date = date_value
+                elif isinstance(date_value, str):
+                    try:
+                        doc_date = date.fromisoformat(date_value)
+                    except ValueError:
+                        pass
+
+            # Extract other fields
+            tags = metadata.get("tags", [])
+            if tags is None:
+                tags = []
+            doc_type = metadata.get("type")
+            author = metadata.get("author")
+
+            doc_info = DocumentInfo(
+                path=file_path,
+                title=title,
+                date=doc_date,
+                tags=tags if isinstance(tags, list) else [],
+                type=doc_type,
+                author=author,
+            )
+            documents.append(doc_info)
+
+        except Exception:
+            # If parsing fails, create a basic document info
+            doc_info = DocumentInfo(
+                path=file_path,
+                title=file_path.stem,
+            )
+            documents.append(doc_info)
+
+    return documents
+
+
+def organize_notes(
+    source_dir: Union[str, Path],
+    target_dir: Union[str, Path],
+    by: str = "date",
+    operation: str = "move",
+    date_format: str = "%Y/%m",
+    dry_run: bool = False,
+) -> OrganizationResult:
+    """
+    Organize notes from source directory to target directory.
+
+    Args:
+        source_dir (Union[str, Path]): Source directory containing notes.
+        target_dir (Union[str, Path]): Target directory for organized notes.
+        by (str): Organization criteria. Options: "date", "tag", "type".
+            Defaults to "date".
+        operation (str): Operation type. Options: "move", "copy".
+            Defaults to "move".
+        date_format (str): Date format for directory structure.
+            Defaults to "%Y/%m" (year/month).
+        dry_run (bool): If True, simulate without making changes.
+            Defaults to False.
+
+    Returns:
+        OrganizationResult: Result of the organization operation.
+
+    Example:
+        >>> result = organize_notes(
+        ...     "notes/",
+        ...     "organized/",
+        ...     by="date",
+        ...     operation="copy"
+        ... )
+        >>> print(f"Organized {result.copied} notes")
+    """
+    # Resolve paths
+    source_path = Path(source_dir)
+    if not source_path.is_absolute():
+        source_path = get_project_root() / source_path
+
+    target_path = Path(target_dir)
+    if not target_path.is_absolute():
+        target_path = get_project_root() / target_path
+
+    # Initialize result
+    result = OrganizationResult()
+
+    # Scan source directory
+    documents = scan_directory(source_path)
+
+    if not documents:
+        return result
+
+    # Create target directory
+    if not dry_run:
+        ensure_directory(target_path)
+
+    # Organize based on criteria
+    if by == "date":
+        _organize_by_date(documents, target_path, operation, date_format, dry_run, result)
+    elif by == "tag":
+        _organize_by_tag(documents, target_path, operation, dry_run, result)
+    elif by == "type":
+        _organize_by_type(documents, target_path, operation, dry_run, result)
+    else:
+        result.errors.append(f"Unknown organization criteria: {by}")
+
+    return result
+
+
+def _organize_by_date(
+    documents: List[DocumentInfo],
+    target_path: Path,
+    operation: str,
+    date_format: str,
+    dry_run: bool,
+    result: OrganizationResult,
+) -> None:
+    """Organize documents by date."""
+    for doc in documents:
+        if doc.date is None:
+            result.skipped += 1
+            continue
+
+        # Create date-based directory
+        date_dir = doc.date.strftime(date_format)
+        dest_dir = target_path / date_dir
+
+        # Perform operation
+        _process_document(doc, dest_dir, operation, dry_run, result)
+
+
+def _organize_by_tag(
+    documents: List[DocumentInfo],
+    target_path: Path,
+    operation: str,
+    dry_run: bool,
+    result: OrganizationResult,
+) -> None:
+    """Organize documents by tags."""
+    for doc in documents:
+        if not doc.tags:
+            # Move to "untagged" directory
+            dest_dir = target_path / "untagged"
+            _process_document(doc, dest_dir, operation, dry_run, result)
+            continue
+
+        # Create a copy for each tag (for copy operation)
+        # Or move to first tag directory (for move operation)
+        if operation == "move":
+            # Move to first tag directory
+            dest_dir = target_path / doc.tags[0]
+            _process_document(doc, dest_dir, operation, dry_run, result)
+        else:
+            # Copy to all tag directories
+            for tag in doc.tags:
+                dest_dir = target_path / tag
+                _process_document(doc, dest_dir, "copy", dry_run, result)
+
+
+def _organize_by_type(
+    documents: List[DocumentInfo],
+    target_path: Path,
+    operation: str,
+    dry_run: bool,
+    result: OrganizationResult,
+) -> None:
+    """Organize documents by type."""
+    for doc in documents:
+        # Use type or "uncategorized"
+        doc_type = doc.type or "uncategorized"
+        dest_dir = target_path / doc_type
+        _process_document(doc, dest_dir, operation, dry_run, result)
+
+
+def _process_document(
+    doc: DocumentInfo,
+    dest_dir: Path,
+    operation: str,
+    dry_run: bool,
+    result: OrganizationResult,
+) -> None:
+    """Process a single document (move or copy)."""
+    try:
+        # Create destination directory
+        if not dry_run:
+            ensure_directory(dest_dir)
+
+        # Determine destination path
+        dest_path = dest_dir / doc.path.name
+
+        # Handle duplicate filenames
+        if dest_path.exists() and dest_path != doc.path:
+            counter = 1
+            stem = doc.path.stem
+            suffix = doc.path.suffix
+            while dest_path.exists():
+                dest_path = dest_dir / f"{stem}_{counter}{suffix}"
+                counter += 1
+
+        # Skip if source and destination are the same
+        if dest_path == doc.path:
+            result.skipped += 1
+            return
+
+        # Perform operation
+        if dry_run:
+            # Just record what would happen
+            result.details[str(doc.path)] = str(dest_path)
+            if operation == "move":
+                result.moved += 1
+            else:
+                result.copied += 1
+        else:
+            if operation == "move":
+                shutil.move(str(doc.path), str(dest_path))
+                result.moved += 1
+            else:
+                shutil.copy2(str(doc.path), str(dest_path))
+                result.copied += 1
+
+            result.details[str(doc.path)] = str(dest_path)
+
+    except Exception as e:
+        result.errors.append(f"Error processing {doc.path}: {e}")
+
+
+def list_organization_plan(
+    source_dir: Union[str, Path],
+    target_dir: Union[str, Path],
+    by: str = "date",
+    date_format: str = "%Y/%m",
+) -> Dict[str, Union[List[tuple], int, List[str]]]:
+    """
+    List the organization plan without making changes.
+
+    This is a convenience function that runs organize_notes with dry_run=True
+    and returns a summary.
+
+    Args:
+        source_dir (Union[str, Path]): Source directory containing notes.
+        target_dir (Union[str, Path]): Target directory for organized notes.
+        by (str): Organization criteria. Options: "date", "tag", "type".
+        date_format (str): Date format for directory structure.
+
+    Returns:
+        Dict with 'moves', 'skipped', and 'errors' keys.
+
+    Example:
+        >>> plan = list_organization_plan("notes/", "organized/", by="date")
+        >>> for src, dst in plan['moves']:
+        ...     print(f"{src} -> {dst}")
+    """
+    result = organize_notes(
+        source_dir, target_dir, by=by, operation="move", date_format=date_format, dry_run=True
+    )
+
+    return {
+        "moves": list(result.details.items()),
+        "skipped": result.skipped,
+        "errors": result.errors,
+    }
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 3:
+        print("Usage: python -m scripts.tools.organize_notes <source> <target> [date|tag|type]")
+        sys.exit(1)
+
+    source = sys.argv[1]
+    target = sys.argv[2]
+    by = sys.argv[3] if len(sys.argv) > 3 else "date"
+
+    result = organize_notes(source, target, by=by)
+    print(f"Moved: {result.moved}, Copied: {result.copied}, Skipped: {result.skipped}")
+    if result.errors:
+        print(f"Errors: {len(result.errors)}")
+        for error in result.errors:
+            print(f"  - {error}")

--- a/tests/test_organize_notes.py
+++ b/tests/test_organize_notes.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""
+Unit tests for note organization tool.
+
+Tests the organize_notes module including:
+- Directory scanning
+- Organization by date/tag/type
+- Move and copy operations
+- Dry run functionality
+"""
+
+import tempfile
+import pytest
+from pathlib import Path
+from datetime import date
+
+from scripts.tools.organize_notes import (
+    DocumentInfo,
+    OrganizationResult,
+    scan_directory,
+    organize_notes,
+    list_organization_plan,
+    _process_document,
+)
+
+
+class TestDocumentInfo:
+    """Test DocumentInfo dataclass"""
+
+    def test_create_basic_document_info(self):
+        """Test creating basic document info"""
+        doc = DocumentInfo(
+            path=Path("/test/doc.md"),
+            title="Test Document",
+        )
+        assert doc.path == Path("/test/doc.md")
+        assert doc.title == "Test Document"
+        assert doc.date is None
+        assert doc.tags == []
+
+    def test_create_full_document_info(self):
+        """Test creating document info with all fields"""
+        doc = DocumentInfo(
+            path=Path("/test/doc.md"),
+            title="Test Document",
+            date=date(2026, 3, 5),
+            tags=["python", "testing"],
+            type="research",
+            author="Test Author",
+        )
+        assert doc.date == date(2026, 3, 5)
+        assert doc.tags == ["python", "testing"]
+        assert doc.type == "research"
+        assert doc.author == "Test Author"
+
+
+class TestOrganizationResult:
+    """Test OrganizationResult dataclass"""
+
+    def test_create_default_result(self):
+        """Test creating result with defaults"""
+        result = OrganizationResult()
+        assert result.moved == 0
+        assert result.copied == 0
+        assert result.skipped == 0
+        assert result.errors == []
+        assert result.details == {}
+
+    def test_create_result_with_values(self):
+        """Test creating result with values"""
+        result = OrganizationResult(
+            moved=5,
+            copied=3,
+            skipped=2,
+            errors=["error1"],
+            details={"src": "dst"},
+        )
+        assert result.moved == 5
+        assert result.copied == 3
+        assert result.skipped == 2
+
+
+class TestScanDirectory:
+    """Test directory scanning functionality"""
+
+    def test_scan_empty_directory(self):
+        """Test scanning empty directory"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            docs = scan_directory(tmpdir)
+            assert docs == []
+
+    def test_scan_single_markdown_file(self):
+        """Test scanning directory with single markdown file"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.md"
+            test_file.write_text("""---
+title: Test Document
+date: 2026-03-05
+tags:
+  - python
+  - testing
+---
+
+Content here.
+""")
+
+            docs = scan_directory(tmpdir)
+
+            assert len(docs) == 1
+            assert docs[0].title == "Test Document"
+            assert docs[0].date == date(2026, 3, 5)
+            assert docs[0].tags == ["python", "testing"]
+
+    def test_scan_no_frontmatter(self):
+        """Test scanning file without frontmatter"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "no_frontmatter.md"
+            test_file.write_text("# Just content\n\nNo frontmatter here.")
+
+            docs = scan_directory(tmpdir)
+
+            assert len(docs) == 1
+            assert docs[0].title == "no_frontmatter"
+
+    def test_scan_nonexistent_directory(self):
+        """Test scanning nonexistent directory"""
+        docs = scan_directory("/nonexistent/path")
+        assert docs == []
+
+    def test_scan_recursive(self):
+        """Test recursive scanning"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = Path(tmpdir) / "subdir"
+            subdir.mkdir()
+
+            (Path(tmpdir) / "root.md").write_text("---\ntitle: Root\n---\nContent")
+            (subdir / "nested.md").write_text("---\ntitle: Nested\n---\nContent")
+
+            docs = scan_directory(tmpdir, recursive=True)
+            assert len(docs) == 2
+
+    def test_scan_non_recursive(self):
+        """Test non-recursive scanning"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = Path(tmpdir) / "subdir"
+            subdir.mkdir()
+
+            (Path(tmpdir) / "root.md").write_text("---\ntitle: Root\n---\nContent")
+            (subdir / "nested.md").write_text("---\ntitle: Nested\n---\nContent")
+
+            docs = scan_directory(tmpdir, recursive=False)
+            assert len(docs) == 1
+
+    def test_scan_with_none_tags(self):
+        """Test scanning when tags is explicitly None"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "test.md"
+            test_file.write_text("""---
+title: Test
+tags:
+---
+Content.
+""")
+
+            docs = scan_directory(tmpdir)
+            assert len(docs) == 1
+            assert docs[0].tags == []
+
+
+class TestOrganizeNotes:
+    """Test note organization functionality"""
+
+    def test_organize_by_date(self):
+        """Test organizing by date"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            # Create test file
+            (source / "jan.md").write_text("---\ntitle: January\ndate: 2026-01-15\n---\nContent")
+            (source / "mar.md").write_text("---\ntitle: March\ndate: 2026-03-05\n---\nContent")
+
+            result = organize_notes(source, target, by="date", operation="copy")
+
+            assert result.copied == 2
+            assert result.skipped == 0
+            assert (target / "2026" / "01" / "jan.md").exists()
+            assert (target / "2026" / "03" / "mar.md").exists()
+
+    def test_organize_by_tag(self):
+        """Test organizing by tag"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "python.md").write_text("---\ntitle: Python\ntags: [python]\n---\nContent")
+            (source / "no_tags.md").write_text("---\ntitle: No Tags\n---\nContent")
+
+            result = organize_notes(source, target, by="tag", operation="copy")
+
+            assert result.copied == 2
+            assert (target / "python" / "python.md").exists()
+            assert (target / "untagged" / "no_tags.md").exists()
+
+    def test_organize_by_type(self):
+        """Test organizing by type"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "research.md").write_text(
+                "---\ntitle: Research\ntype: research\n---\nContent"
+            )
+            (source / "meeting.md").write_text("---\ntitle: Meeting\ntype: meeting\n---\nContent")
+            (source / "no_type.md").write_text("---\ntitle: No Type\n---\nContent")
+
+            result = organize_notes(source, target, by="type", operation="copy")
+
+            assert result.copied == 3
+            assert (target / "research" / "research.md").exists()
+            assert (target / "meeting" / "meeting.md").exists()
+            assert (target / "uncategorized" / "no_type.md").exists()
+
+    def test_organize_move_operation(self):
+        """Test move operation"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "doc.md").write_text("---\ntitle: Doc\ndate: 2026-03-05\n---\nContent")
+
+            result = organize_notes(source, target, by="date", operation="move")
+
+            assert result.moved == 1
+            assert not (source / "doc.md").exists()
+            assert (target / "2026" / "03" / "doc.md").exists()
+
+    def test_organize_copy_operation(self):
+        """Test copy operation"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "doc.md").write_text("---\ntitle: Doc\ndate: 2026-03-05\n---\nContent")
+
+            result = organize_notes(source, target, by="date", operation="copy")
+
+            assert result.copied == 1
+            assert (source / "doc.md").exists()
+            assert (target / "2026" / "03" / "doc.md").exists()
+
+    def test_organize_dry_run(self):
+        """Test dry run mode"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "doc.md").write_text("---\ntitle: Doc\ndate: 2026-03-05\n---\nContent")
+
+            result = organize_notes(source, target, by="date", operation="move", dry_run=True)
+
+            assert result.moved == 1
+            assert (source / "doc.md").exists()
+            assert not (target / "2026" / "03" / "doc.md").exists()
+
+    def test_organize_skip_no_date(self):
+        """Test skipping documents without date when organizing by date"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "with_date.md").write_text(
+                "---\ntitle: With Date\ndate: 2026-03-05\n---\nContent"
+            )
+            (source / "no_date.md").write_text("---\ntitle: No Date\n---\nContent")
+
+            result = organize_notes(source, target, by="date", operation="copy")
+
+            assert result.copied == 1
+            assert result.skipped == 1
+
+    def test_organize_duplicate_filenames(self):
+        """Test handling duplicate filenames"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            # Create file in target with same name
+            target_date = target / "2026" / "03"
+            target_date.mkdir(parents=True)
+            (target_date / "doc.md").write_text("Existing content")
+
+            (source / "doc.md").write_text("---\ntitle: Doc\ndate: 2026-03-05\n---\nContent")
+
+            result = organize_notes(source, target, by="date", operation="copy")
+
+            assert result.copied == 1
+            assert (target_date / "doc.md").exists()
+            assert (target_date / "doc_1.md").exists()
+
+    def test_organize_custom_date_format(self):
+        """Test custom date format"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "doc.md").write_text("---\ntitle: Doc\ndate: 2026-03-05\n---\nContent")
+
+            result = organize_notes(
+                source, target, by="date", operation="copy", date_format="%Y-%m"
+            )
+
+            assert result.copied == 1
+            assert (target / "2026-03" / "doc.md").exists()
+
+    def test_organize_unknown_criteria(self):
+        """Test unknown organization criteria"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "doc.md").write_text("---\ntitle: Doc\n---\nContent")
+
+            result = organize_notes(source, target, by="unknown")
+
+            assert len(result.errors) == 1
+            assert "unknown" in result.errors[0]
+
+    def test_organize_empty_source(self):
+        """Test organizing empty source directory"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            result = organize_notes(source, target, by="date")
+
+            assert result.moved == 0
+            assert result.copied == 0
+
+
+class TestOrganizeByTagCopy:
+    """Test organizing by tag with copy operation"""
+
+    def test_organize_by_tag_copy_to_all_tags(self):
+        """Test copying to all tag directories"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "doc.md").write_text("---\ntitle: Doc\ntags: [python, testing]\n---\nContent")
+
+            result = organize_notes(source, target, by="tag", operation="copy")
+
+            # Should copy to both tag directories
+            assert result.copied == 2
+            assert (target / "python" / "doc.md").exists()
+            assert (target / "testing" / "doc.md").exists()
+
+
+class TestListOrganizationPlan:
+    """Test list_organization_plan function"""
+
+    def test_list_plan_basic(self):
+        """Test listing organization plan"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "doc.md").write_text("---\ntitle: Doc\ndate: 2026-03-05\n---\nContent")
+
+            plan = list_organization_plan(source, target, by="date")
+
+            assert len(plan["moves"]) == 1
+            assert plan["skipped"] == 0
+            assert plan["errors"] == []
+
+    def test_list_plan_with_skip(self):
+        """Test listing plan with skipped files"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "with_date.md").write_text(
+                "---\ntitle: With Date\ndate: 2026-03-05\n---\nContent"
+            )
+            (source / "no_date.md").write_text("---\ntitle: No Date\n---\nContent")
+
+            plan = list_organization_plan(source, target, by="date")
+
+            assert len(plan["moves"]) == 1
+            assert plan["skipped"] == 1
+
+
+class TestProcessDocument:
+    """Test _process_document helper function"""
+
+    def test_process_document_skip_same_path(self):
+        """Test skipping when source and destination are the same"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = DocumentInfo(
+                path=Path(tmpdir) / "doc.md",
+                title="Doc",
+            )
+            result = OrganizationResult()
+
+            _process_document(doc, Path(tmpdir), "move", False, result)
+
+            assert result.skipped == 1
+            assert result.moved == 0
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling"""
+
+    def test_scan_file_with_invalid_yaml(self):
+        """Test scanning file with invalid YAML"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "invalid.md"
+            test_file.write_text("""---
+title: [broken yaml
+---
+Content.
+""")
+
+            docs = scan_directory(tmpdir)
+            assert len(docs) == 1
+            assert docs[0].title == "invalid"
+
+    def test_organize_preserves_content(self):
+        """Test that organization preserves file content"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            original_content = """---
+title: Test
+date: 2026-03-05
+---
+
+# Test Content
+
+Some body text.
+"""
+            (source / "doc.md").write_text(original_content)
+
+            organize_notes(source, target, by="date", operation="copy")
+
+            target_file = target / "2026" / "03" / "doc.md"
+            assert target_file.read_text() == original_content
+
+    def test_organize_tag_move_uses_first_tag(self):
+        """Test that move operation uses first tag only"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source"
+            target = Path(tmpdir) / "target"
+            source.mkdir()
+
+            (source / "doc.md").write_text("---\ntitle: Doc\ntags: [python, testing]\n---\nContent")
+
+            result = organize_notes(source, target, by="tag", operation="move")
+
+            # Should move to first tag only
+            assert result.moved == 1
+            assert (target / "python" / "doc.md").exists()
+            assert not (target / "testing" / "doc.md").exists()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- 实现 `scripts/tools/organize_notes.py` 笔记整理工具
- 支持 `scan_directory()` 扫描目录下的 Markdown 文件
- 支持 `organize_notes()` 按日期/标签/类型组织笔记
- 支持 move 和 copy 操作
- 支持 dry_run 模式预览
- 处理重复文件名

## 功能特性
- ✅ 按日期组织笔记（自定义日期格式）
- ✅ 按标签分类笔记
- ✅ 按类型分类笔记
- ✅ 支持 move 操作（移动原文件）
- ✅ 支持 copy 操作（保留原文件）
- ✅ dry_run 模式预览变更
- ✅ 处理重复文件名
- ✅ 测试覆盖率 85%

## Test Plan
- [x] 29 个单元测试全部通过
- [x] 测试覆盖率 >80%（实际 85%）
- [x] Black 格式化检查通过
- [x] 不修改其他 Team 的模块

Closes #25